### PR TITLE
Switch from Ubuntu to Clear Linux AWS image.

### DIFF
--- a/build_scripts/build_ami.py
+++ b/build_scripts/build_ami.py
@@ -1,12 +1,70 @@
 # flake8: noqa
 
 """
-A script to create a meadowrun EC2 AMI.
+A script to create a meadowrun EC2 BASE AMI. The only reason to want to change the base
+AMI is because you want to change the version or flavour of Linux/Docker/Python we're
+using, or some other deep baked-into-the-OS thing. To update meadowrun, you just need to
+run the script below without going through these manual steps.
 
-The main prerequisite for this script is an AMI that has that has ubuntu, docker, and
-python installed, referenced as _BASE_AMI. To build this AMI (which should also be
+The main prerequisite for this script is an AMI that has that has Linux, Docker, and
+Python installed, referenced as _BASE_AMI. To build this base AMI (which should also be
 automated):
 
+
+Clear Linux 
+-----------
+Clear Linux has the fastest boot times, see https://www.daemonology.net/blog/2021-08-12-EC2-boot-time-benchmarking.html)
+
+New option: use Clear Linux - Launch an EC2 instance using the Clear Linux AMI
+(https://clearlinux.org/download). Use a 4Gb EBS volume.
+
+- ssh into the instance: `ssh -i key_pair.pem clear@public-dns-of-instance`
+- Run `sudo swupd update`
+- Disable automatic updates (otherwise swupd will automatically update at at startup, using resources): sudo swupd autoupdate --disable
+- Enable SFTP: https://docs.01.org/clearlinux/latest/guides/network/openssh-server.html?highlight=ssh#id4
+    ```echo 'subsystem sftp /usr/libexec/sftp-server' | sudo tee -a /etc/ssh/sshd_config```
+- Install cron & allow clear user to use it
+    `sudo swupd bundle-add cronie`
+    `sudo systemctl enable cronie`
+    `echo clear | sudo tee -a /etc/cron.allow`
+- Install Docker: `sudo swupd bundle-add containers-basic`
+- [Add the current user (clear) to the docker group](https://www.digitalocean.com/community/questions/how-to-fix-docker-got-permission-denied-while-trying-to-connect-to-the-docker-daemon-socket): `sudo usermod -aG docker ${USER}`
+- Install Python: `sudo swupd bundle-add python-basic`
+
+-
+Prepare a virtualenv for meadowrun
+```shell
+sudo mkdir /var/meadowrun 
+sudo chown clear:clear /var/meadowrun
+mkdir /var/meadowrun/env
+python -m venv /var/meadowrun/env
+source /var/meadowrun/env/bin/activate
+python -m pip install --upgrade pip
+pip install wheel  # not sure why this is necessary...
+```
+
+- Get the versions of everything we've installed:
+```shell
+swupd info  # Clear Linux version
+docker --version
+python --version
+```
+Now, since the Clean Linux image is "sold" for 0 dollars on AWS Marketplace, we can't make any AMIs public.
+This is not a problem for Clear Linux, as it's free anyway, but some technical AWS limitation to protect actually
+for-pay marketplace AMIs.
+To work around this, we'll remove the AWS marketplace code: https://www.caseylabs.com/remove-the-aws-marketplace-code-from-a-centos-ami/
+- Create a 4Gb EBS volume in the same availability region as your EC2 instance.
+- Attach the volume to your EC2 instance.
+- Prepare the volume:
+    - `sudo lsblk -f` should show the volumne id. It might be different from what AWS tells you. Assuming in what follows it's /dev/xvdf.
+    - format it: `sudo mkfs -t ext4 /dev/xvdf`
+- Copy the root volume to the new volume - assuming root volume is /dev/xvda: `sudo dd bs=1M if=/dev/xvda of=/dev/xvdf` 
+- Shutdown (do not terminate yet!) the instance.
+- 
+
+
+Ubuntu
+------
 - Launch an EC2 instance using the "Ubuntu Server 20.04 LTS (HVM), SSD Volume Type"
 quickstart AMI.
 - ssh into the instance: `ssh -i path/to/key.pem ubuntu@public-dns-of-instance`. The following instructions should be run on the EC2 instance.
@@ -69,8 +127,8 @@ from meadowrun.aws_integration.ec2_ssh_keys import (
     get_meadowrun_ssh_key,
 )
 
-_BASE_AMI = "ami-01344892e448f48c2"
-_NEW_AMI_NAME = "meadowrun-ec2alloc-{}-ubuntu-20.04.3-docker-20.10.12-python-3.9.5"
+_BASE_AMI = "ami-022142958961ee96e"
+_NEW_AMI_NAME = "meadowrun-ec2alloc-{}-clear-36520-docker-20.10.11-python-3.10.5"
 
 
 async def build_meadowrun_ami():

--- a/build_scripts/build_ami.py
+++ b/build_scripts/build_ami.py
@@ -182,7 +182,9 @@ async def build_meadowrun_ami():
         user=SSH_USER,
         connect_kwargs={"pkey": pkey},
     ) as connection:
-        await upload_and_configure_meadowrun(connection, version, package_root_dir)
+        await upload_and_configure_meadowrun(
+            connection, version, package_root_dir, pre_command="sudo swupd update"
+        )
 
     # get the instance id of our EC2 instance
     instances = client.describe_instances(

--- a/build_scripts/build_image_shared.py
+++ b/build_scripts/build_image_shared.py
@@ -1,6 +1,6 @@
 import os
 import io
-from typing import cast
+from typing import Optional, cast
 
 import fabric
 import paramiko.ssh_exception
@@ -9,7 +9,10 @@ from meadowrun.run_job_core import _retry
 
 
 async def upload_and_configure_meadowrun(
-    connection: fabric.Connection, version: str, package_root_dir: str
+    connection: fabric.Connection,
+    version: str,
+    package_root_dir: str,
+    pre_command: Optional[str] = None,
 ) -> None:
     # retry with a no-op until we've established a connection
     await _retry(
@@ -19,6 +22,9 @@ async def upload_and_configure_meadowrun(
             cast(Exception, TimeoutError),
         ),
     )
+
+    if pre_command:
+        connection.run(pre_command)
 
     # install the meadowrun package
     connection.put(

--- a/build_scripts/build_image_shared.py
+++ b/build_scripts/build_image_shared.py
@@ -37,6 +37,13 @@ async def upload_and_configure_meadowrun(
     )
     connection.run(f"rm /var/meadowrun/meadowrun-{version}-py3-none-any.whl")
 
+    # compile the meadowrun env to pyc - this reduces initial startup time
+    connection.run(
+        "/var/meadowrun/env/bin/python -m compileall /var/meadowrun/env/lib",
+        # returns non-zero if syntax errors are found, but compiles most files anyway
+        warn=True,
+    )
+
     # set deallocate_jobs to run from crontab
     crontab_line = (
         "* * * * * /var/meadowrun/env/bin/python -m meadowrun.deallocate_jobs "

--- a/src/meadowrun/aws_integration/config.py
+++ b/src/meadowrun/aws_integration/config.py
@@ -1,1 +1,1 @@
-SSH_USER = "ubuntu"
+SSH_USER = "clear"

--- a/src/meadowrun/aws_integration/ec2_instance_allocation.py
+++ b/src/meadowrun/aws_integration/ec2_instance_allocation.py
@@ -47,7 +47,7 @@ from meadowrun.run_job_core import AllocCloudInstancesInternal, JobCompletion, S
 # AMIs that have meadowrun pre-installed. These are all identical, we just need to
 # replicate into each region.
 _EC2_ALLOC_AMIS = {
-    "us-east-2": "ami-010934a0fa91c336e",
+    "us-east-2": "ami-08bcd5071508ebecf",
     "us-east-1": "ami-023ef6195ecb8e648",
     "us-west-1": "ami-032b1753347534924",
     "us-west-2": "ami-074513d806ac4d30e",

--- a/src/meadowrun/aws_integration/ec2_instance_allocation.py
+++ b/src/meadowrun/aws_integration/ec2_instance_allocation.py
@@ -47,7 +47,7 @@ from meadowrun.run_job_core import AllocCloudInstancesInternal, JobCompletion, S
 # AMIs that have meadowrun pre-installed. These are all identical, we just need to
 # replicate into each region.
 _EC2_ALLOC_AMIS = {
-    "us-east-2": "ami-07653668da87ca748",
+    "us-east-2": "ami-010934a0fa91c336e",
     "us-east-1": "ami-023ef6195ecb8e648",
     "us-west-1": "ami-032b1753347534924",
     "us-west-2": "ami-074513d806ac4d30e",


### PR DESCRIPTION
This improves time to SSH into new EC2 significantly.

With the attached benchmark script, one run_function timings for 10 runs were:

image | min | median | max|
-------|-----|---------|----|
CLEAR    |  36.03|    42.56|    56.17|
UBUNTU | 56.00|    64.87 |   71.37|