### PR TITLE
More minor fixes

### DIFF
--- a/docker_images/cuda-python/CudaPythonDockerfile
+++ b/docker_images/cuda-python/CudaPythonDockerfile
@@ -1,9 +1,16 @@
 FROM meadowrun/cuda-deadsnakes:cuda11.6.2-cudnn8-ubuntu20.04
 
 ARG PYTHON_VERSION
-RUN apt install -y python$PYTHON_VERSION python$PYTHON_VERSION-venv && \
+RUN apt update && \
+    apt install -y python$PYTHON_VERSION python$PYTHON_VERSION-venv && \
     apt clean && \
     rm -rf /var/lib/apt && \
     update-alternatives --install /usr/bin/python3 python3 /usr/bin/python$PYTHON_VERSION 1 && \
     update-alternatives --install /usr/bin/python python /usr/bin/python$PYTHON_VERSION 1 && \
-    python -m ensurepip
+    python -c 'import urllib.request; urllib.request.urlretrieve("https://bootstrap.pypa.io/get-pip.py", "get-pip.py")' && \
+    python get-pip.py && \
+    python -m pip install wheel
+
+# above, we need to use get-pip.py because depending on which release of python we get,
+# ensurepip will fail with "ensurepip is disabled in debian/ubuntu for the system
+# python"

--- a/src/meadowrun/aws_integration/ec2.py
+++ b/src/meadowrun/aws_integration/ec2.py
@@ -152,7 +152,10 @@ def ensure_security_group(group_name: str, region_name: str) -> str:
             Description=group_name,
             GroupName=group_name,
             TagSpecifications=[
-                {"Tags": [{"Key": _EC2_ALLOC_TAG, "Value": _EC2_ALLOC_TAG_VALUE}]}
+                {
+                    "ResourceType": "security-group",
+                    "Tags": [{"Key": _EC2_ALLOC_TAG, "Value": _EC2_ALLOC_TAG_VALUE}],
+                }
             ],
         )
     return security_group.id
@@ -444,7 +447,11 @@ async def _launch_instance_continuation(instance: Any) -> str:
 
     instance.load()
     if not instance.public_dns_name:
-        raise ValueError("Waited until running, but still no IP address!")
+        # try one more time after waiting 1 seconds
+        await asyncio.sleep(1.0)
+        instance.load()
+        if not instance.public_dns_name:
+            raise ValueError("Waited until running, but still no IP address!")
     return instance.public_dns_name
 
 

--- a/src/meadowrun/deployment_manager.py
+++ b/src/meadowrun/deployment_manager.py
@@ -251,14 +251,7 @@ async def _get_zip_file_code_paths(
         ]
 
     async def download_and_unzip(
-        download: Callable[
-            [
-                str,
-                str,
-                str,
-            ],
-            Coroutine[Any, Any, None],
-        ]
+        download: Callable[[str, str, str], Coroutine[Any, Any, None]],
     ) -> List[str]:
         bucket_name = decoded_url.netloc
         object_name = decoded_url.path.lstrip("/")
@@ -297,8 +290,6 @@ async def compile_environment_spec_to_container(
     path_to_spec, spec_hash, has_git_dependency = _get_path_and_hash(
         environment_spec, interpreter_spec_path
     )
-
-    print(f"Building python environment in container {spec_hash}")
 
     if cloud is None:
         helper = ContainerRegistryHelper(
@@ -341,6 +332,8 @@ async def compile_environment_spec_to_container(
 
     # the image doesn't exist locally or in ECR, so build it ourselves and cache it in
     # ECR
+
+    print(f"Building python environment in container {spec_hash}")
 
     build_args = {}
     files_to_copy = []

--- a/src/meadowrun/docker_controller.py
+++ b/src/meadowrun/docker_controller.py
@@ -444,7 +444,10 @@ async def run_container(
             # of replacing localhost for the coordinator address. Also:
             # https://stackoverflow.com/questions/31324981/how-to-access-host-port-from-docker-container/43541732#43541732
             "ExtraHosts": ["host.docker.internal:host-gateway"],
-            "AutoRemove": True,
+            # Ideally we would have some sort of "AutoRemove after 5 minutes". With
+            # AutoRemove turned on, containers can get deleted before we are able to
+            # read off their exit codes.
+            # "AutoRemove": True,
         },
     }
 

--- a/src/meadowrun/manage.py
+++ b/src/meadowrun/manage.py
@@ -87,6 +87,7 @@ async def async_main(cloud_provider: CloudProviderType) -> None:
         vm_instances = "EC2 instances"
         ssh_user = SSH_USER
         vm_instance_address = "<ec2-instance-public-address>"
+        ecr = "ECR"
     elif cloud_provider == "AzureVM":
         functions = "Azure Functions"
         cloud_name = "Azure"
@@ -95,6 +96,7 @@ async def async_main(cloud_provider: CloudProviderType) -> None:
         vm_instances = "Azure VMs"
         ssh_user = _MEADOWRUN_USERNAME
         vm_instance_address = "<azure-vm-public-ip>"
+        ecr = "ACR"
     else:
         raise ValueError(f"Unexpected value for cloud_provider {cloud_provider}")
 
@@ -243,7 +245,7 @@ async def async_main(cloud_provider: CloudProviderType) -> None:
         )
         t0 = time.perf_counter()
 
-        print("Deleting unused meadowrun-generated ECR images")
+        print(f"Deleting unused meadowrun-generated {ecr} images")
         if cloud_provider == "EC2":
             aws_delete_unused_images(region_name)
         elif cloud_provider == "AzureVM":
@@ -252,7 +254,7 @@ async def async_main(cloud_provider: CloudProviderType) -> None:
         else:
             raise ValueError(f"Unexpected cloud_provider {cloud_provider}")
         print(
-            "Deleted unused meadowrun-generated ECR images in "
+            f"Deleted unused meadowrun-generated {ecr} images in "
             f"{time.perf_counter() - t0:.2f} seconds"
         )
     elif args.command == "grant-permission-to-secret":

--- a/tests/basics.py
+++ b/tests/basics.py
@@ -456,7 +456,9 @@ class MapSuite(abc.ABC):
         results = await run_map(
             lambda x: x**x,
             [1, 2, 3, 4],
-            AllocCloudInstances(1, 1, 15, self.cloud_provider(), 3),
+            AllocCloudInstances(
+                1, 1, 15, self.cloud_provider(), num_concurrent_tasks=3
+            ),
         )
 
         assert results == [1, 4, 27, 256]


### PR DESCRIPTION
- Retry one time if an EC2 instance's public dns name is not available
- Revert setting AutoRemove for docker containers, sometimes we aren't able to read the exit code
- Make formatting more concise
- Fix manage.py logging that said ECR instead of ACR for Azure
- Fix test_run_map which hadn't been updated for the new API
- For building cuda-python images, run apt update and install pip via get-pip.py, as ensurepip doesn't work in some cases
- Fix a bug in ensure_security_group that was causing creating security groups to fail