### PR TITLE
Clarify timezones.

### DIFF
--- a/src/meadowrun/aws_integration/ec2_instance_allocation.py
+++ b/src/meadowrun/aws_integration/ec2_instance_allocation.py
@@ -98,7 +98,7 @@ _U = TypeVar("_U")
 # replicate into each region.
 _AMIS = {
     "plain": {
-        "us-east-2": "ami-0f683863cc95a0505",
+        "us-east-2": "ami-03d6f2ce2696d0dc0",
         "us-east-1": "ami-095487ef77cf08c11",
         "us-west-1": "ami-0c361c736028dd007",
         "us-west-2": "ami-0c5e4fa0f0f779f57",


### PR DESCRIPTION
ISO string in allocation table is UTC time, but was interpreted as a naive datetime.