### PR TITLE
Bug fix: Avoid unpickling in agent process.

### DIFF
--- a/src/meadowrun/aws_integration/ec2_instance_allocation.py
+++ b/src/meadowrun/aws_integration/ec2_instance_allocation.py
@@ -100,7 +100,7 @@ _U = TypeVar("_U")
 # replicate into each region.
 _AMIS = {
     "plain": {
-        "us-east-2": "ami-0349ef9d9837e8d22",
+        "us-east-2": "ami-08f51d17f4ee0508a",
         "us-east-1": "ami-04e6314b2f5d04d72",
         "us-west-1": "ami-0f58f85636c629179",
         "us-west-2": "ami-01102db1f2f623e36",

--- a/src/meadowrun/aws_integration/grid_tasks_sqs.py
+++ b/src/meadowrun/aws_integration/grid_tasks_sqs.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import itertools
 import json
 import os
-import pickle
 import time
 import traceback
 from typing import (
@@ -281,7 +280,7 @@ async def _worker_iteration(
             if state == "SUCCEEDED"
             else ProcessState.ProcessStateEnum.PYTHON_EXCEPTION,
             pid=pid,
-            pickled_result=pickle.dumps(result, protocol=pickle.HIGHEST_PROTOCOL),
+            pickled_result=result,
             return_code=0,
             log_file_name=log_file_name,
             max_memory_used_gb=stats.max_memory_used_gb,

--- a/src/meadowrun/azure_integration/grid_tasks_queue.py
+++ b/src/meadowrun/azure_integration/grid_tasks_queue.py
@@ -223,7 +223,7 @@ async def _worker_iteration(
             if state == "SUCCEEDED"
             else ProcessState.ProcessStateEnum.PYTHON_EXCEPTION,
             pid=pid,
-            pickled_result=pickle.dumps(result, protocol=pickle.HIGHEST_PROTOCOL),
+            pickled_result=result,
             return_code=0,
             log_file_name=log_file_name,
             max_memory_used_gb=stats.max_memory_used_gb,

--- a/tests/example_user_code/example_package/example.py
+++ b/tests/example_user_code/example_package/example.py
@@ -29,3 +29,7 @@ def tetration(x: float) -> float:
 
 def crash(_: Any) -> None:
     sys.exit(123)
+
+
+def the_same(inp: Any) -> Any:
+    return inp


### PR DESCRIPTION
The agent does not run in the worker environment, so trying to unpickle a worker result can cause problems.
Also add a safe unpickle on the client side, so failure to unpickle does not fail the run_map job.