### PR TITLE
Documentation updates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ AWS, Azure, or Kubernetes. Meadowrun:
   they're no longer needed.
   
 For more context, see our [case
-studes](https://docs.meadowrun.io/en/stable/case_studies/) of how Meadowrun is used in
+studies](https://docs.meadowrun.io/en/stable/case_studies/) of how Meadowrun is used in
 real life, or see the [project homepage](https://meadowrun.io)
 
 To get started, go to our [documentation](https://docs.meadowrun.io), or [join the chat

--- a/docs/explanation/deployment.md
+++ b/docs/explanation/deployment.md
@@ -1,7 +1,7 @@
 # How deployment works
 
 This page gives a deep dive into how deployment in Meadowrun works. For a quick overview
-and examples, see the [Meadowrun deployment tutorial](../../tutorial/deployment).
+and examples, see the [Meadowrun deployment overview](../../reference/deployment).
 
 Meadowrun makes it easy to get your **code** and libraries, which we'll refer to as your
 **interpreter**, into the cloud.
@@ -47,7 +47,7 @@ machine. In this case, the Meadowrun worker will pull the specified image from t
 specified container registry.
 
 {%
-include-markdown "../tutorial/deployment.md"
+include-markdown "../reference/deployment.md"
 start="<!--containerauth-start-->"
 end="<!--containerauth-end-->"
 %} With this option, your local
@@ -65,7 +65,7 @@ Use `git_repo` when you want to run with code that's been deployed to a git repo
 Meadowrun worker will pull the specified branch/commit.
 
 {%
-include-markdown "../tutorial/deployment.md"
+include-markdown "../reference/deployment.md"
 start="<!--gitrepoauth-start-->"
 end="<!--gitrepoauth-end-->"
 %}
@@ -90,7 +90,7 @@ container. In this case, the Meadowrun worker will pull the specified image from
 specified container registry.
 
 {%
-include-markdown "../tutorial/deployment.md"
+include-markdown "../reference/deployment.md"
 start="<!--containerauth-start-->"
 end="<!--containerauth-end-->"
 %}

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ AWS, Azure, or Kubernetes. Meadowrun:
 - optimizes for cost, choosing the cheapest instance types and turning them off when
   they're no longer needed.
   
-For more context, see our [case studes](case_studies) of how Meadowrun is used in real
+For more context, see our [case studies](case_studies) of how Meadowrun is used in real
 life, or see the [project homepage](https://meadowrun.io)
 
 ## Quickstart

--- a/docs/reference/.pages
+++ b/docs/reference/.pages
@@ -1,4 +1,6 @@
 nav:
+- entry_points.md
+- deployment.md
 - apis.md
 - aws_resources.md
 - azure_resources.md

--- a/docs/reference/apis.md
+++ b/docs/reference/apis.md
@@ -1,4 +1,4 @@
-# Meadowrun APIs
+# API Reference
 
 ## Main entry points
 

--- a/docs/reference/deployment.md
+++ b/docs/reference/deployment.md
@@ -1,4 +1,4 @@
-# Meadowrun deployment tutorial
+# Deployment options overview
 
 This page gives quick examples of how to use the main deployment options in Meadowrun.
 Also see [How deployment works](../../explanation/deployment) for a look at what's

--- a/docs/reference/entry_points.md
+++ b/docs/reference/entry_points.md
@@ -1,11 +1,11 @@
-# Meadowrun entry points tutorial
+# Entry points overview
 
-This page gives quick examples of how to use each of Meadowrun's entrypoints.
+This page gives quick examples of how to use each of Meadowrun's entry points.
 
 <!--quickstarted-start-->
 We will assume you've gone through either the quickstart or one of the tutorials for a
-specific platform ([AWS EC2](../aws_ec2), [Azure VMs](../azure_vm),
-[GKE](../gke), or [Kubernetes](../kubernetes)). In the examples, we'll use
+specific platform ([AWS EC2](../../tutorial/aws_ec2), [Azure VMs](../../tutorial/azure_vm),
+[GKE](../../tutorial/gke), or [Kubernetes](../../tutorial/kubernetes)). In the examples, we'll use
 `host` and `resources` variables that we don't define here. You will need to define
 these variables as they were defined (as parameters) in the platform-specific tutorials.
 <!--quickstarted-end-->
@@ -23,16 +23,15 @@ Returns `499.5`.
 
 ## [`run_command`][meadowrun.run_command]
 
-Runs a command remotely. See [Run a Jupyter notebook remotely](../jupyter_notebook) for
+Runs a command remotely. See [Run a Jupyter notebook remotely](../../tutorial/jupyter_notebook) for
 a fully worked example of using `run_command`.
 
 ## [`run_map`][meadowrun.run_map]
 
 `run_map` is like the built-in
-[`map`](https://docs.python.org/3/library/functions.html#map) function, but it runs
-in parallel and remotely. This is a powerful tool for scaling computations on the cloud
-that makes it easy to use hundreds or thousands of cores in parallel to process large
-data sets.
+[`map`](https://docs.python.org/3/library/functions.html#map) function, but it runs in
+parallel and remotely. This is a powerful tool for scaling computations: easily use
+hundreds or thousands of cores in parallel to process large data sets.
 
 Example:
 
@@ -81,4 +80,7 @@ The output is:
 
 In general, there's no guarantee what order the results come back in.
 
-`run_map` is recommended for most use cases.
+`run_map` is recommended for most use cases. Consider using `run_map_as_completed` if
+your use case requires further processing of results locally, and you'd like to
+interleave this processing with executing the tasks. This could be beneficial if the
+processing is time-intensive.

--- a/docs/tutorial/.pages
+++ b/docs/tutorial/.pages
@@ -3,6 +3,4 @@ nav:
 - azure_vm.md
 - gke.md
 - kubernetes.md
-- entry_points.md
 - jupyter_notebook.md
-- deployment.md

--- a/docs/tutorial/aws_ec2.md
+++ b/docs/tutorial/aws_ec2.md
@@ -1,4 +1,4 @@
-# Run Meadowrun on AWS EC2
+# Run a Python function on AWS EC2
 
 This page walks you through running a function on an EC2 instance using your local code
 and libraries.
@@ -112,12 +112,12 @@ remote output to the local output.
 
 ## Next steps
 
-- In addition to `run_function`, Meadowrun provides [other entrypoints](../entry_points).
+- In addition to `run_function`, Meadowrun provides [other entrypoints](../../reference/entry_points).
   The most important of these is [`run_map`][meadowrun.run_map], which allows you to use
   many EC2 instances in parallel.
 <!--aws-azure-generic-next-steps-start-->
 - By default, Meadowrun will mirror your current local deployment, but there are [other
-  ways to specify the code and libraries](../deployment) you want to use when running
+  ways to specify the code and libraries](../../reference/deployment) you want to use when running
   remotely.
 - If you want non-administrator users to use Meadowrun, you'll need to [grant them
   permissions to use Meadowrun](../../how_to/user_permissions).

--- a/docs/tutorial/azure_vm.md
+++ b/docs/tutorial/azure_vm.md
@@ -1,4 +1,4 @@
-# Run Meadowrun on Azure VMs
+# Run a Python function on Azure VMs
 
 This page walks you through running a function on an Azure VM using your local code and
 libraries.
@@ -111,7 +111,7 @@ remote output to the local output.
 
 ## Next steps
 
-- In addition to `run_function`, Meadowrun provides [other entrypoints](../entry_points).
+- In addition to `run_function`, Meadowrun provides [other entrypoints](../../reference/entry_points).
   The most important of these is [`run_map`][meadowrun.run_map], which allows you to use
   many VMs in parallel.
 

--- a/docs/tutorial/gke.md
+++ b/docs/tutorial/gke.md
@@ -1,4 +1,4 @@
-# Run Meadowrun on GKE (Google Kubernetes Engine)
+# Run a Python function on GKE (Google Kubernetes Engine)
 
 This page walks you through running a function on a GKE cluster using your local code
 and libraries. No need to build any containers!

--- a/docs/tutorial/jupyter_notebook.md
+++ b/docs/tutorial/jupyter_notebook.md
@@ -4,7 +4,7 @@ This page walks through an example of how to run a Jupyter notebook server using
 Meadowrun.
 
 {%
-include-markdown "entry_points.md"
+include-markdown "../reference/entry_points.md"
 start="<!--quickstarted-start-->"
 end="<!--quickstarted-end-->"
 %}

--- a/docs/tutorial/kubernetes.md
+++ b/docs/tutorial/kubernetes.md
@@ -1,4 +1,4 @@
-# Run Meadowrun on Kubernetes (Minikube)
+# Run a Python function on Kubernetes (Minikube)
 
 This page shows how to run Meadowrun on Kubernetes using
 [Minikube](https://minikube.sigs.k8s.io/docs/start/). Minikube isn't useful for
@@ -267,10 +267,10 @@ is doing:
 ## Next steps
 
 - In addition to `run_function`, Meadowrun provides [other
-  entrypoints](../entry_points). The most important of these is
+  entry points](../../reference/entry_points). The most important of these is
   [`run_map`][meadowrun.run_map], which allows you to use many pods in parallel.
 - By default, Meadowrun will mirror your current local deployment, but there are [other
-  ways to specify the code and libraries](../deployment) you want to use when running
+  ways to specify the code and libraries](../../reference/deployment) you want to use when running
   remotely.
 - Learn more about [how Meadowrun uses Kubernetes
   resources](../../reference/kubernetes_resources)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,10 +28,12 @@ plugins:
       redirect_maps:
         'tutorial/install.md': 'index.md'
         'tutorial/run_function.md': 'tutorial/aws_ec2.md'
-        'tutorial/run_function_git_conda.md': 'tutorial/deployment.md'
-        'tutorial/run_command_in_container.md': 'tutorial/deployment.md'
-        'tutorial/run_map.md': 'tutorial/entry_points.md'
+        'tutorial/run_function_git_conda.md': 'reference/deployment.md'
+        'tutorial/run_command_in_container.md': 'reference/deployment.md'
+        'tutorial/run_map.md': 'reference/entry_points.md'
         'how_to/kubernetes.md': 'tutorial/kubernetes.md'
+        'tutorial/entry_points.md': 'reference/entry_points.md'
+        'tutorial/deployment.md': 'reference/deployment.md'
 markdown_extensions:
   - pymdownx.superfences
   - pymdownx.tabbed:


### PR DESCRIPTION
Moved entry points and deployment overview to reference section. Reworded titles of tutorials from "Run Meadowrun" to "Run a python function".
Few small additions and fixes.