### PR TITLE
Performance improvements to short grid jobs

### DIFF
--- a/build_scripts/build_ami_helper.py
+++ b/build_scripts/build_ami_helper.py
@@ -5,7 +5,6 @@ import re
 import traceback
 from typing import (
     TYPE_CHECKING,
-    Any,
     Awaitable,
     Callable,
     Dict,
@@ -35,7 +34,7 @@ from meadowrun.aws_integration.ec2_ssh_keys import (
     ensure_meadowrun_key_pair,
 )
 from meadowrun.run_job_core import _retry
-from meadowrun.ssh import connect, run_and_capture
+from meadowrun.ssh import connect, run_and_capture_str
 
 if TYPE_CHECKING:
     from mypy_boto3_ec2 import EC2Client
@@ -249,17 +248,8 @@ async def build_amis(
                 )
 
 
-def _assert_str(s: Any) -> str:
-    """Helper function just for mypy"""
-    if not isinstance(s, str):
-        raise ValueError(f"Expected a string but got {type(s)}")
-    return s
-
-
 async def parse_ubuntu_version(connection: asyncssh.SSHClientConnection) -> str:
-    ubuntu_version = _assert_str(
-        (await run_and_capture(connection, "lsb_release -a")).stdout
-    ).strip()
+    ubuntu_version = await run_and_capture_str(connection, "lsb_release -a")
 
     match = re.match(
         r"Description:\s+Ubuntu (?P<version_string>[\d.]+)( LTS)?",
@@ -271,9 +261,7 @@ async def parse_ubuntu_version(connection: asyncssh.SSHClientConnection) -> str:
 
 
 async def parse_docker_version(connection: asyncssh.SSHClientConnection) -> str:
-    docker_version = _assert_str(
-        (await run_and_capture(connection, "docker --version")).stdout
-    ).strip()
+    docker_version = await run_and_capture_str(connection, "docker --version")
 
     match = re.match(r"Docker version (?P<version_string>[\d.]+),", docker_version)
     if match is None:
@@ -284,9 +272,7 @@ async def parse_docker_version(connection: asyncssh.SSHClientConnection) -> str:
 async def parse_python_version(
     connection: asyncssh.SSHClientConnection, python: str
 ) -> str:
-    python_version = _assert_str(
-        (await run_and_capture(connection, f"{python} --version")).stdout
-    ).strip()
+    python_version = await run_and_capture_str(connection, f"{python} --version")
 
     match = re.match(r"Python (?P<version_string>[\d.]+)", python_version)
     if match is None:

--- a/build_scripts/build_base_ami.py
+++ b/build_scripts/build_base_ami.py
@@ -12,9 +12,8 @@ from build_ami_helper import (
     build_amis,
     _check_for_existing_amis,
     BEHAVIOR_OPTIONS,
-    _assert_str,
 )
-from meadowrun.ssh import run_and_print, run_and_capture, write_text_to_file
+from meadowrun.ssh import run_and_print, write_text_to_file, run_and_capture_str
 
 
 async def prepare_meadowrun_virtual_env(
@@ -143,9 +142,9 @@ async def cuda_base_image_actions_on_vm(
 
 
 async def parse_cuda_version(connection: asyncssh.SSHClientConnection) -> str:
-    nvcc_version = _assert_str(
-        (await run_and_capture(connection, "/usr/local/cuda/bin/nvcc --version")).stdout
-    ).strip()
+    nvcc_version = await run_and_capture_str(
+        connection, "/usr/local/cuda/bin/nvcc --version"
+    )
 
     match = re.match(
         r"Cuda compilation tools, release (?P<version_string>[\d.]+),",

--- a/build_scripts/build_image_shared.py
+++ b/build_scripts/build_image_shared.py
@@ -10,7 +10,7 @@ from meadowrun.run_job_local import MACHINE_CACHE_FOLDER
 if TYPE_CHECKING:
     from meadowrun.run_job_core import CloudProviderType
 from meadowrun.ssh import (
-    run_and_capture,
+    run_and_capture_str,
     run_and_print,
     upload_file,
     write_text_to_file,
@@ -55,13 +55,7 @@ async def upload_and_configure_meadowrun(
         check=False,
     )
 
-    output = (await run_and_capture(connection, "echo $HOME")).stdout
-    if output is None:
-        raise ValueError("Result of echo $HOME was None")
-    if isinstance(output, bytes):
-        home_dir = output.decode("utf-8").strip()
-    else:
-        home_dir = output.strip()
+    home_dir = await run_and_capture_str(connection, "echo $HOME")
     systemd_config_dir = "/etc/systemd/system/"
 
     # set deallocate_jobs to run via systemd timer
@@ -139,13 +133,7 @@ async def upload_and_configure_meadowrun(
     )
 
     if machine_agent_module:
-        user_output = (await run_and_capture(connection, "whoami")).stdout
-        if not user_output:
-            raise ValueError("whoami returned None")
-        if isinstance(user_output, bytes):
-            user = user_output.decode("utf-8").strip()
-        else:
-            user = user_output.strip()
+        user = await run_and_capture_str(connection, "whoami")
         await write_text_to_file(
             connection,
             "[Unit]\n"

--- a/src/meadowrun/abstract_storage_bucket.py
+++ b/src/meadowrun/abstract_storage_bucket.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import abc
-from typing import Optional, Type, Tuple, List, TYPE_CHECKING
+from typing import Optional, Type, Tuple, List, TYPE_CHECKING, Iterable
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -91,3 +91,7 @@ class AbstractStorageBucket(abc.ABC):
     @abc.abstractmethod
     async def delete_object(self, key: str) -> None:
         ...
+
+    async def delete_objects(self, keys: Iterable[str]) -> None:
+        for key in keys:
+            await self.delete_object(key)

--- a/src/meadowrun/aws_integration/ec2_instance_allocation.py
+++ b/src/meadowrun/aws_integration/ec2_instance_allocation.py
@@ -821,14 +821,15 @@ class EC2GridJobInterface(GridJobCloudInterface):
             await self._sqs_client.__aexit__(exc_type, exc_val, exc_tb)
 
         if self._s3_bucket is not None:
-            for key in await self._s3_bucket.list_objects(
-                storage_prefix_outputs(self._base_job_id)
-            ):
-                await self._s3_bucket.delete_object(key)
-            for key in await self._s3_bucket.list_objects(
-                storage_prefix_inputs(self._base_job_id)
-            ):
-                await self._s3_bucket.delete_object(key)
+            keys_to_delete = itertools.chain(
+                await self._s3_bucket.list_objects(
+                    storage_prefix_outputs(self._base_job_id)
+                ),
+                await self._s3_bucket.list_objects(
+                    storage_prefix_inputs(self._base_job_id)
+                ),
+            )
+            await self._s3_bucket.delete_objects(keys_to_delete)
 
             await self._s3_bucket.__aexit__(exc_type, exc_val, exc_tb)
 

--- a/src/meadowrun/docker_controller.py
+++ b/src/meadowrun/docker_controller.py
@@ -462,6 +462,8 @@ async def run_container(
             # https://stackoverflow.com/questions/31324981/how-to-access-host-port-from-docker-container/43541732#43541732
             "ExtraHosts": ["host.docker.internal:host-gateway"]
             + [f"{host_name}:{ip}" for host_name, ip in extra_hosts],
+            # See https://github.com/moby/moby/issues/42096
+            "NetworkMode": "host",
             # Ideally we would have some sort of "AutoRemove after 5 minutes". With
             # AutoRemove turned on, containers can get deleted before we are able to
             # read off their exit codes.

--- a/src/meadowrun/ssh.py
+++ b/src/meadowrun/ssh.py
@@ -72,6 +72,18 @@ async def run_and_capture(
     return await connection.run(command, check=check)
 
 
+async def run_and_capture_str(
+    connection: asyncssh.SSHClientConnection, command: str
+) -> str:
+    output = (await run_and_capture(connection, command)).stdout
+    if output is None:
+        raise ValueError(f"Result of `{command}` was None")
+    if isinstance(output, bytes):
+        return output.decode("utf-8").strip()
+    else:
+        return output.strip()
+
+
 async def write_to_file(
     connection: asyncssh.SSHClientConnection, bys: bytes, remote_path: str
 ) -> None:

--- a/src/meadowrun/storage_grid_job.py
+++ b/src/meadowrun/storage_grid_job.py
@@ -159,6 +159,12 @@ class GenericStorageBucket(AbstractStorageBucket):
     async def delete_object(self, key: str) -> None:
         await self._s3_client.delete_object(Bucket=self._bucket, Key=key)
 
+    async def delete_objects(self, keys: Iterable[str]) -> None:
+        await self._s3_client.delete_objects(
+            Bucket=self._bucket,
+            Delete={"Objects": [{"Key": key} for key in keys], "Quiet": True},
+        )
+
 
 class S3Bucket(GenericStorageBucket):
     """


### PR DESCRIPTION
Focuses on a benchmark running 128 tasks doing `time.sleep(3)`, 64 at a time. Theoretical performance is 6s, anything over that is overhead. E.g.:

```
    def remote_func(i):
        time.sleep(3)
        return i ** i

    result = asyncio.run(meadowrun.run_map(
        remote_func,
        range(128),
        meadowrun.AllocEC2Instance(),
        meadowrun.Resources(1, 2, 80),
        meadowrun.Deployment.mirror_local(
            interpreter=meadowrun.PipRequirementsString(["cloudpickle"], "3.9"),
        ),
        num_concurrent_tasks=64))
```

Before this pull request, this snippet took about 24s, after it takes about 14s.

This takes care of the very low hanging fruit. Remaining overhead:

|     Section          |     Seconds     |
|------------------------------------------|------------|
|     Start to launched   workers          |     2     |
|     Docker overhead   (64 containers)    |     3      |
|     to last   remote_func                |     1.5    |
|     Actual execution   time              |     6      |
|     Receive + delay                      |     1.5    |
|     Shutdown                             |     1      |